### PR TITLE
auto create cloudwatch log group

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ufo (1.5.0)
+    ufo (1.6.3)
       aws-sdk
       colorize
       deep_merge
@@ -20,14 +20,14 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    aws-sdk (2.9.37)
-      aws-sdk-resources (= 2.9.37)
-    aws-sdk-core (2.9.37)
+    aws-sdk (2.10.21)
+      aws-sdk-resources (= 2.10.21)
+    aws-sdk-core (2.10.21)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.37)
-      aws-sdk-core (= 2.9.37)
-    aws-sigv4 (1.0.0)
+    aws-sdk-resources (2.10.21)
+      aws-sdk-core (= 2.10.21)
+    aws-sigv4 (1.0.1)
     builder (3.2.3)
     byebug (9.0.6)
     codeclimate-test-reporter (1.0.8)
@@ -37,10 +37,10 @@ GEM
     diff-lcs (1.3)
     docile (1.1.5)
     hashie (3.5.5)
-    i18n (0.8.4)
+    i18n (0.8.6)
     jmespath (1.3.1)
     json (2.1.0)
-    minitest (5.10.2)
+    minitest (5.10.3)
     plissken (0.3.0)
       symbolize (~> 4.2)
     rake (12.0.0)

--- a/lib/ufo.rb
+++ b/lib/ufo.rb
@@ -17,6 +17,7 @@ module Ufo
   autoload :Destroy, 'ufo/destroy'
   autoload :DSL, 'ufo/dsl'
   autoload :Scale, 'ufo/scale'
+  autoload :LogGroup, 'ufo/log_group'
 
   autoload :Docker, 'ufo/docker'
   autoload :Ecr, 'ufo/ecr'

--- a/lib/ufo/aws_services.rb
+++ b/lib/ufo/aws_services.rb
@@ -13,5 +13,9 @@ module Ufo
     def ecr
       @ecr ||= Aws::ECR::Client.new
     end
+
+    def cloudwatchlogs
+      @cloudwatchlogs ||= Aws::CloudWatchLogs::Client.new
+    end
   end
 end

--- a/lib/ufo/cli.rb
+++ b/lib/ufo/cli.rb
@@ -49,6 +49,7 @@ module Ufo
 
       task_definition = options[:task] || service # convention
       Tasks::Builder.register(task_definition, options) if options[:tasks]
+      LogGroup.new(task_definition, options).create
       ship = Ship.new(service, task_definition, options)
       ship.deploy
 
@@ -65,6 +66,7 @@ module Ufo
         service_name, task_defintion_name = service.split(':')
         task_definition = task_defintion_name || service_name # convention
         Tasks::Builder.register(task_definition, options) if options[:tasks]
+        LogGroup.new(task_definition, options).create
         ship = Ship.new(service, task_definition, options)
         ship.deploy
       end

--- a/lib/ufo/log_group.rb
+++ b/lib/ufo/log_group.rb
@@ -1,0 +1,33 @@
+# Use to automatically create the CloudWatch group
+module Ufo
+  class LogGroup
+    include AwsServices
+
+    def initialize(task_definition, options)
+      @task_definition, @options = task_definition, options
+    end
+
+    def create
+      puts "Ensuring log group for #{@task_definition} exists"
+      return if @options[:noop]
+      task_def = JSON.load(IO.read(task_def_path))
+      task_def["containerDefinitions"].each do |container_def|
+        begin
+          log_group_name = container_def["logConfiguration"]["options"]["awslogs-group"]
+        rescue NoMethodError
+          # silence when the logConfiguration is not specified
+        end
+
+        create_log_group(log_group_name) if log_group_name
+      end
+    end
+
+    def create_log_group(log_group_name)
+      cloudwatchlogs.create_log_group(log_group_name: log_group_name)
+    end
+
+    def task_def_path
+      "./ufo/output/#{@task_definition}.json"
+    end
+  end
+end

--- a/lib/ufo/settings.rb
+++ b/lib/ufo/settings.rb
@@ -15,7 +15,7 @@ module Ufo
         @data = YAML.load_file(settings_path)
         @data = user_settings.merge(@data)
       else
-        puts "ERROR: No settings file at #{settings_path}"
+        puts "ERROR: No settings file at #{settings_path}.  Are you sure you are in a project with ufo setup?"
         puts "Please create a settings file via: ufo init"
         exit 1
       end


### PR DESCRIPTION
It's pretty easy to forget to create a CloudWatch log group manually. This automatically creates the log group.