### PR TITLE
Correcting builder class in one time task

### DIFF
--- a/lib/ufo/docker/builder.rb
+++ b/lib/ufo/docker/builder.rb
@@ -8,7 +8,7 @@ class Ufo::Docker
     def self.build(options)
       builder = Builder.new(options) # outside if because it need builder.full_image_name
       builder.build
-      pusher = Docker::Pusher.new(nil, options)
+      pusher = Pusher.new(nil, options)
       pusher.push
       builder
     end


### PR DESCRIPTION
Due to issues related to one time task command, I'm providing a working fix, to a following error:
```
/Users/abolinger/.rvm/gems/ruby-2.4.2/gems/ufo-3.3.1/lib/ufo/docker/builder.rb:11:in `build': uninitialized constant Ufo::Docker::Builder::Docker (NameError)
Did you mean?  Ufo::Docker
    from /Users/abolinger/.rvm/gems/ruby-2.4.2/gems/ufo-3.3.1/lib/ufo/cli.rb:82:in `task'
```


Signed-off-by: Adam Bolinger <adam.bolinger@netguru.co>