### PR TITLE
service_cluster map setting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ufo (4.4.2)
+    ufo (4.4.3)
       aws-sdk-cloudformation
       aws-sdk-cloudwatchlogs
       aws-sdk-ec2
@@ -25,7 +25,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     aws-eventstream (1.0.3)
-    aws-partitions (1.171.0)
+    aws-partitions (1.172.0)
     aws-sdk-cloudformation (1.22.0)
       aws-sdk-core (~> 3, >= 3.53.0)
       aws-sigv4 (~> 1.1)
@@ -37,7 +37,7 @@ GEM
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-ec2 (1.89.0)
+    aws-sdk-ec2 (1.90.0)
       aws-sdk-core (~> 3, >= 3.53.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ecr (1.17.0)

--- a/docs/_docs/conventions.md
+++ b/docs/_docs/conventions.md
@@ -1,6 +1,6 @@
 ---
 title: Conventions
-nav_order: 18
+nav_order: 19
 ---
 
 Ufo uses a set of naming conventions.  This helps enforce some best practices and also allows the ufo commands to be concise.  You can override or bypass the conventions easily.

--- a/docs/_docs/extras/codebuild-iam-role.md
+++ b/docs/_docs/extras/codebuild-iam-role.md
@@ -1,6 +1,6 @@
 ---
 title: CodeBuild IAM Role
-nav_order: 29
+nav_order: 31
 ---
 
 Note, the `/tmp/ecs-deploy-policy.json` policy is available at [Minimal Deploy IAM]({% link _docs/extras/minimal-deploy-iam.md %}).

--- a/docs/_docs/extras/ecs-network-mode.md
+++ b/docs/_docs/extras/ecs-network-mode.md
@@ -1,6 +1,6 @@
 ---
 title: ECS Network Mode
-nav_order: 24
+nav_order: 26
 ---
 
 ## Pros and Cons: awsvpc vs bridge network mode

--- a/docs/_docs/extras/load-balancer.md
+++ b/docs/_docs/extras/load-balancer.md
@@ -1,6 +1,6 @@
 ---
 title: Load Balancer Support
-nav_order: 22
+nav_order: 24
 ---
 
 Ufo can automatically create a load balancer and associate it with an ECS service.  The options:

--- a/docs/_docs/extras/minimal-deploy-iam.md
+++ b/docs/_docs/extras/minimal-deploy-iam.md
@@ -1,6 +1,6 @@
 ---
 title: Minimal Deploy IAM Policy
-nav_order: 28
+nav_order: 30
 ---
 
 The IAM user you use to run the `ufo ship` command needs a minimal set of IAM policies in order to deploy to ECS. Here is a table of the baseline services needed:

--- a/docs/_docs/extras/redirection-support.md
+++ b/docs/_docs/extras/redirection-support.md
@@ -1,6 +1,6 @@
 ---
 title: Redirection Support
-nav_order: 27
+nav_order: 29
 ---
 
 ## Application Load Balancers

--- a/docs/_docs/extras/route53-support.md
+++ b/docs/_docs/extras/route53-support.md
@@ -1,6 +1,6 @@
 ---
 title: Route53 Support
-nav_order: 26
+nav_order: 28
 ---
 
 Ufo can create a "pretty" route53 record and set it's value to the created ELB DNS name. This is done by configuring the `.ufo/settings/cfn/default.yml` file. Example:

--- a/docs/_docs/extras/security-groups.md
+++ b/docs/_docs/extras/security-groups.md
@@ -1,6 +1,6 @@
 ---
 title: Security Groups
-nav_order: 23
+nav_order: 25
 ---
 
 Ufo creates and manages two security groups. One for the ELB and one for the ECS tasks.

--- a/docs/_docs/extras/ssl-support.md
+++ b/docs/_docs/extras/ssl-support.md
@@ -1,6 +1,6 @@
 ---
 title: SSL Support
-nav_order: 25
+nav_order: 27
 ---
 
 You can configure SSL support by uncomment the `listener_ssl` option in `.ufo/settings/cfn/default.yml`.  Here's an example:

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-nav_order: 41
+nav_order: 43
 ---
 
 **Q: Is AWS ECS Fargate supported?**
@@ -8,7 +8,7 @@ nav_order: 41
 Yes, Fargate is supported.  To use ufo with Fargate, you will need to adjust the template in `.ufo/templates` to a structure supported by Fargate.  There are 2 key items to adjust:
 
 1. The task definition JSON. Notably, the JSON structure has the `requiresCompatibilities`, `networkMode`, and `executionRoleArn` attributes. The `cpu` and `memory` attributes also move outside of the `containerDefinitions` level to the top-level attributes. For details on how to adjust the task definition refer to [Task Definitions]({% link _docs/tutorial-ufo-tasks-build.md %}).
-2. The params that get sent to the `run_task` API methods. For details on how to adjust the params refer to [Params]({% link _docs/params.md %})
+2. The params that get sent to the `run_task` API methods. For details on how to adjust the params refer to [Params]({% link _docs/ufo-task-params.md %})
 
 If it's a brand new project, you can use `ufo init` with the `--launch-type fargate` option and it will generate a starter task definition JSON file that has the right Fargate structure. More info is available at [ufo init reference](/reference/ufo-init/#fargate-support).
 

--- a/docs/_docs/helpers.md
+++ b/docs/_docs/helpers.md
@@ -1,6 +1,6 @@
 ---
 title: Helpers
-nav_order: 17
+nav_order: 18
 ---
 
 The `task_definitions.rb` file has access to helper methods. These helper methods provide useful contextual information about the project.

--- a/docs/_docs/more/auto-completion.md
+++ b/docs/_docs/more/auto-completion.md
@@ -1,28 +1,24 @@
 ---
 title: Auto Completion
-nav_order: 40
+nav_order: 42
 ---
 
 Ufo supports bash auto-completion.  To set it up add the following to your `~/.profile` or `.bashrc`:
 
-```
-eval $(ufo completion_script)
-```
+    eval $(ufo completion_script)
 
 Remember to restart your shell or source your profile file.
 
 Auto Completion examples:
 
-```
-ufo [TAB]
-ufo ship [TAB]
-ufo ship demo-web [TAB]
-ufo ship demo-web --[TAB]
-ufo ship --[TAB]
-ufo docker [TAB]
-ufo docker build [TAB]
-ufo tasks [TAB]
-ufo tasks build [TAB]
-```
+    ufo [TAB]
+    ufo ship [TAB]
+    ufo ship demo-web [TAB]
+    ufo ship demo-web --[TAB]
+    ufo ship --[TAB]
+    ufo docker [TAB]
+    ufo docker build [TAB]
+    ufo tasks [TAB]
+    ufo tasks build [TAB]
 
 {% include prev_next.md %}

--- a/docs/_docs/more/automated-cleanup.md
+++ b/docs/_docs/more/automated-cleanup.md
@@ -1,6 +1,6 @@
 ---
 title: Automated Clean Up
-nav_order: 39
+nav_order: 41
 ---
 
 Ufo can be configured to automatically clean old images from the ECR registry after the deploy completes by configuring your [settings.yml]({% link _docs/settings.md %}) file like so:

--- a/docs/_docs/more/customize-cloudformation.md
+++ b/docs/_docs/more/customize-cloudformation.md
@@ -1,6 +1,6 @@
 ---
 title: Customize CloudFormation
-nav_order: 34
+nav_order: 36
 ---
 
 Under the hood, ufo creates most of the required resources with a CloudFormation stack.  This includes the ELB, Target Group, Listener, Security Groups, ECS Service, and Route 53 records.  You might need to customize these resources.  Here are the ways to customize the resources that ufo creates.
@@ -20,13 +20,13 @@ You can override the source template that ufo uses by creating your own and savi
 
 ## CloudFormation Stack Name
 
-The CloudFormation stack name is based on the cluster, service name and UFO_ENV_EXTRA.  A few examples help demonstrate:
+The CloudFormation stack name is based on the service name, UFO_ENV and UFO_ENV_EXTRA.  A few examples help demonstrate:
 
 Command | Stack Name
 --- | ---
-ufo ship demo-web | development-demo-web
-ufo ship demo-web -\-cluster dev | dev-demo-web
-UFO_ENV_EXTRA=2 ufo ship demo-web -\-cluster dev | development-demo-web-2
+ufo ship demo-web | demo-web-development
+ufo ship demo-web -\-cluster dev | demo-web-development
+UFO_ENV_EXTRA=2 ufo ship demo-web -\-cluster dev | demo-web-development-2
 
 ## CloudFormation Stack Source Code
 

--- a/docs/_docs/more/migrations.md
+++ b/docs/_docs/more/migrations.md
@@ -1,26 +1,20 @@
 ---
 title: Database Migrations
-nav_order: 38
+nav_order: 40
 ---
 
 A common task is to run database migrations with newer code before deploying the code. This is easily achieved with the `ufo task` command. Here's an example:
 
-```sh
-ufo task demo-web -c bundle exec rake db:migrate
-```
+    ufo task demo-web -c bundle exec rake db:migrate
 
 It is nice to wrap the commands in a wrapper script in case you have to do things like to load the environment.
 
-```sh
-ufo task demo-web -c bin/migrate
-```
+    ufo task demo-web -c bin/migrate
 
 The `bin/migrate` script can look like this:
 
-```bash
-#!/bin/bash
-bundle exec rake db:migrate
-```
+    #!/bin/bash
+    bundle exec rake db:migrate
 
 The `ufo task` command is generalized so you can run any one-off task. It is not just limited to running migrations. The `ufo task` command performs the following:
 

--- a/docs/_docs/more/run-in-pieces.md
+++ b/docs/_docs/more/run-in-pieces.md
@@ -1,6 +1,6 @@
 ---
 title: Run in Pieces
-nav_order: 36
+nav_order: 38
 ---
 
 The `ufo ship` command goes through a few stages:
@@ -13,23 +13,17 @@ The CLI exposes many of these steps as separate commands.  Here is now you would
 
 Build the docker image first.
 
-```bash
-ufo docker build
-ufo docker push # pushes last built image to a registry
-```
+    ufo docker build
+    ufo docker push # pushes last built image to a registry
 
 Build the task definitions.
 
-```bash
-ufo tasks build    # generates task definition json files to .ufo/output
-ufo tasks register # registers all genreated task definitions .ufo/output to ECS
-```
+    ufo tasks build    # generates task definition json files to .ufo/output
+    ufo tasks register # registers all genreated task definitions .ufo/output to ECS
 
 Update the service with the task definitions in `.ufo/output` untouched.
 
-```bash
-ufo deploy demo-web
-```
+    ufo deploy demo-web
 
 Note if you use the `ufo deploy` you should ensure that you have already pushed the docker image to your docker registry.  Or else the task will not be able to spin up because the docker image does not exist.  This is one of the reasons it is recommended that you use `ufo ship`.
 

--- a/docs/_docs/more/single-task.md
+++ b/docs/_docs/more/single-task.md
@@ -1,29 +1,24 @@
 ---
 title: Run Single Task
-nav_order: 37
+nav_order: 39
 ---
 
 Sometimes you do not want to run a long running `service` but a one time task. Running Rails migrations are an example of a one off task.  Here is an example of how you would run a one time task.
 
-```
-ufo task demo-web -c bundle exec rake db:migrate
-```
+    ufo task demo-web -c bundle exec rake db:migrate
 
 At the end of the output you should see you the task ARN:
 
-```sh
-$ ufo task demo-web -c bundle exec rake db:migrate
-...
-Running task_definition: demo-web
-Task ARN: arn:aws:ecs:us-west-2:994926937775:task/a0e4229d-3d39-4b26-9151-6ab6869b84d4
-$
-```
+
+    $ ufo task demo-web -c bundle exec rake db:migrate
+    ...
+    Running task_definition: demo-web
+    Task ARN: arn:aws:ecs:us-west-2:994926937775:task/a0e4229d-3d39-4b26-9151-6ab6869b84d4
+    $
 
 You can describe that task for more details:
 
-```sh
-aws ecs describe-tasks --tasks arn:aws:ecs:us-west-2:994926937775:task/a0e4229d-3d39-4b26-9151-6ab6869b84d4
-```
+    aws ecs describe-tasks --tasks arn:aws:ecs:us-west-2:994926937775:task/a0e4229d-3d39-4b26-9151-6ab6869b84d4
 
 You can check out the [ufo task](http://ufoships.com/reference/ufo-task/) reference for more details.
 

--- a/docs/_docs/more/stuck-cloudformation.md
+++ b/docs/_docs/more/stuck-cloudformation.md
@@ -1,6 +1,6 @@
 ---
 title: Stuck CloudFormation
-nav_order: 35
+nav_order: 37
 ---
 
 The CloudFormation stack update or creation can get stuck in a `*_IN_PROGRESS` state for a very long time, like more than an hour.  This happens when you deploy an ECS service that fails to stabilize. Usually, this is an error with the Docker container failing to start up successfully.

--- a/docs/_docs/more/why-cloudformation.md
+++ b/docs/_docs/more/why-cloudformation.md
@@ -1,6 +1,6 @@
 ---
 title: Why CloudFormation
-nav_order: 33
+nav_order: 35
 ---
 
 Version 3 of ufo was a simpler implementation and did not make use of CloudFormation to create the ECS service. In version 4, ufo uses CloudFormation to create the ECS Service.  This is because ufo became more powerful. Notably, support for Load Balancers was added. With this power, also came added complexity. So the complexity was push onto CloudFormation.  Hence, ECS service is implemented as CloudFormation resource in version 4.

--- a/docs/_docs/next-steps.md
+++ b/docs/_docs/next-steps.md
@@ -1,6 +1,6 @@
 ---
 title: Next Steps
-nav_order: 43
+nav_order: 45
 ---
 
 This concludes the tutorial guide for ufo. Hopefully you are now more comfortable with ufo's basic usage, concepts, and have a feel for the workflow.

--- a/docs/_docs/settings.md
+++ b/docs/_docs/settings.md
@@ -43,69 +43,12 @@ Setting  | Description
 `image`  | The `image` value is the name that ufo will use for the Docker image name to be built.  Only provide the basename part of the image name without the tag because ufo automatically generates the tag for you. For example, `tongueroo/demo-ufo` is correct and `tongueroo/demo-ufo:my-tag` is incorrect.
 `network_profile` | The name of the network profile settings file to use. Maps to .ufo/settings/network/NAME.yml file
 
-## ECS Cluster Convention
-
-Normally, the ECS cluster defaults to whatever UFO_ENV is set to by [convention]({% link _docs/conventions.md %}).  For example, when `UFO_ENV=production` the ECS Cluster is `production` and when `UFO_ENV=development` the ECS Cluster is `development`.  There are several ways to override this behavior. Let's go through an example:
-
-By default, these are all the same:
-
-```sh
-ufo ship demo-web
-UFO_ENV=development ufo ship demo-web # same
-UFO_ENV=development ufo ship demo-web --cluster development # same
-```
-
-If you use a specific `UFO_ENV=production`, these are the same
-
-```
-UFO_ENV=production ufo ship demo-web
-UFO_ENV=production ufo ship demo-web --cluster production # same
-```
-
-Override the convention by explicitly specifying the `--cluster` option in the CLI.
-
-```sh
-ufo ship demo-web --cluster custom-cluster # override the cluster
-UFO_ENV=production ufo ship demo-web --cluster production-cluster # override the cluster
-```
-
-Override the convention by setting the cluster option in the `settings.yml` file, so you won't have to specify the `--cluster` option in the command repeatedly.
-
-```yaml
-development:
-  cluster: dev
-
-production:
-  cluster: prod
-```
-
-
 ## AWS_PROFILE support
 
-An interesting option is `aws_profile`.  Here's an example:
+An interesting option is `aws_profile`.  This allows you to tightly connect an AWS_PROFILE to a UFO_ENV. The details are in the [Settings AWS_PROFILE docs]({% link _docs/settings/aws_profile.md %}).
 
-```yaml
-development:
-  aws_profile: dev_profile
+## ECS Cluster Convention
 
-production:
-  aws_profile: prod_profile
-```
-
-This provides a way to tightly bind `UFO_ENV` to `AWS_PROFILE`.  This prevents you from forgetting to switch your `UFO_ENV` when switching your `AWS_PROFILE` thereby accidentally launching a stack in the wrong environment.
-
-
-AWS_PROFILE | UFO_ENV | Notes
---- | --- | ---
-dev_profile | development
-prod_profile | production
-whatever | development | default since whatever is not found in settings.yml
-
-The binding is two-way. So:
-
-    UFO_ENV=production ufo ship # will deploy to the AWS_PROFILE=prod_profile
-    AWS_PROFILE=prod_profile ufo ship # will deploy to the UFO_ENV=production
-
-This behavior prevents you from switching `AWS_PROFILE`s, forgetting to switch `UFO_ENV` and then accidentally deploying a production based docker image to development and vice versa because you forgot to also switch `UFO_ENV` to its respective environment.
+Normally, the ECS cluster defaults to whatever UFO_ENV is set to by [convention]({% link _docs/conventions.md %}).  For example, when `UFO_ENV=production` the ECS Cluster is `production` and when `UFO_ENV=development` the ECS Cluster is `development`.  There are several ways to override this behavior. This is detailed in the [Settings Cluster docs]({% link _docs/settings/cluster.md %}).
 
 {% include prev_next.md %}

--- a/docs/_docs/settings/aws_profile.md
+++ b/docs/_docs/settings/aws_profile.md
@@ -1,0 +1,36 @@
+---
+title: Settings AWS_PROFILE
+short_title: AWS Profile
+categories: settings
+nav_order: 13
+---
+
+## AWS_PROFILE support
+
+An interesting option is `aws_profile`.  Here's an example:
+
+```yaml
+development:
+  aws_profile: dev_profile
+
+production:
+  aws_profile: prod_profile
+```
+
+This provides a way to tightly bind `UFO_ENV` to `AWS_PROFILE`.  This prevents you from forgetting to switch your `UFO_ENV` when switching your `AWS_PROFILE` thereby accidentally launching a stack in the wrong environment.
+
+
+AWS_PROFILE | UFO_ENV | Notes
+--- | --- | ---
+dev_profile | development
+prod_profile | production
+whatever | development | default since whatever is not found in settings.yml
+
+The binding is two-way. So:
+
+    UFO_ENV=production ufo ship # will deploy to the AWS_PROFILE=prod_profile
+    AWS_PROFILE=prod_profile ufo ship # will deploy to the UFO_ENV=production
+
+This behavior prevents you from switching `AWS_PROFILE`s, forgetting to switch `UFO_ENV` and then accidentally deploying a production based docker image to development and vice versa because you forgot to also switch `UFO_ENV` to its respective environment.
+
+{% include prev_next.md %}

--- a/docs/_docs/settings/cfn.md
+++ b/docs/_docs/settings/cfn.md
@@ -1,5 +1,7 @@
 ---
 title: Settings Cfn
+short_title: Cfn
+categories: settings
 nav_order: 14
 ---
 

--- a/docs/_docs/settings/cluster.md
+++ b/docs/_docs/settings/cluster.md
@@ -1,0 +1,72 @@
+---
+title: Settings Cluster
+short_title: Cluster
+categories: settings
+nav_order: 15
+---
+
+Normally, the ECS cluster defaults to whatever UFO_ENV is set to by [convention]({% link _docs/conventions.md %}).  For example, when `UFO_ENV=production` the ECS Cluster is `production` and when `UFO_ENV=development` the ECS Cluster is `development`.  There are several ways to override this behavior. Let's go through some examples.
+
+## CLI Override
+
+By default, these are all the same:
+
+```sh
+ufo ship demo-web
+UFO_ENV=development ufo ship demo-web # same
+UFO_ENV=development ufo ship demo-web --cluster development # same
+```
+
+If you use a specific `UFO_ENV=production`, these are the same
+
+```
+UFO_ENV=production ufo ship demo-web
+UFO_ENV=production ufo ship demo-web --cluster production # same
+```
+
+Override the convention by explicitly specifying the `--cluster` option in the CLI.
+
+```sh
+ufo ship demo-web --cluster custom-cluster # override the cluster
+UFO_ENV=production ufo ship demo-web --cluster production-cluster # override the cluster
+```
+
+The cavaet is that you must remember to specify `--cluster`.  A wrapper `bin/deploy` script could be useful here.
+
+## Environment Cluster Setting
+
+If you don't want to specify the `--cluster` option in the command repeatedly, you can configure the cluster based on the the UFO_ENV.  Setting the `cluster` option in the `settings.yml` file:
+
+```yaml
+development:
+  cluster: dev
+
+production:
+  cluster: prod
+```
+
+## Service Cluster Setting
+
+Another interesting way of specifying the cluster to use is with the `service_cluster` option.  The `service_cluster` option takes a Hash value. Here's an example:
+
+```yaml
+base:
+  service_cluster:
+    demo-web: web-fleet
+    demo-worker: worker-fleet
+```
+
+In this example, ufo will deploy the demo-web service to the web-fleet ECS cluster and the demo-worker service to the worker-fleet ECS cluster.
+
+Also since the service_cluster is configured in the base section, it is used for all `UFO_ENV=development`, `UFO_ENV=production`, etc.
+
+## Precendence
+
+The precedence of the settings from highest to lowest is:
+
+* cli option
+* service_cluster service specific setting
+* cluster environment setting
+* UFO_ENV default convention
+
+{% include prev_next.md %}

--- a/docs/_docs/settings/network.md
+++ b/docs/_docs/settings/network.md
@@ -1,6 +1,8 @@
 ---
 title: Settings Network
-nav_order: 13
+short_title: Network
+categories: settings
+nav_order: 16
 ---
 
 The settings.yml file references a network settings file with the `network_profile` option. This file has configurations that are related to the network.  The source code for the starter template file is at [network/default.yml.tt](https://github.com/tongueroo/ufo/blob/master/lib/template/.ufo/settings/network/default.yml.tt)  Here's an example network settings file.

--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -26,7 +26,7 @@ The table below covers the purpose of each folder and file.
 File / Directory  | Description
 ------------- | -------------
 <code>output/</code>  | The folder where the generated task definitions are written to.  The way the task definitions are generated is covered in [ufo tasks build]({% link _docs/tutorial-ufo-tasks-build.md %}).
-<code>params</code>  | This is where you can adjust the params that get send to the aws-sdk api calls. More info at [Params]({% link _docs/params.md %}).
+<code>params</code>  | This is where you can adjust the params that get send to the aws-sdk api calls for the [ufo task](https://ufoships.com/reference/ufo-task/) command. More info at [Params]({% link _docs/ufo-task-params.md %}).
 <code>settings.yml</code>  | Ufo's general settings file, where you adjust the default [settings]({% link _docs/settings.md %}).
 <code>settings/cfn/default.yml</code>  | Ufo's cfn settings. You can customize the CloudFormation resource properties here.
 <code>settings/network/default.yml</code>  | Ufo's network settings. You can customize the vpc and subnets to used here.

--- a/docs/_docs/ufo-current.md
+++ b/docs/_docs/ufo-current.md
@@ -1,6 +1,6 @@
 ---
 title: Ufo Current
-nav_order: 21
+nav_order: 22
 ---
 
 ## service

--- a/docs/_docs/ufo-env-extra.md
+++ b/docs/_docs/ufo-env-extra.md
@@ -1,6 +1,6 @@
 ---
 title: UFO_ENV_EXTRA
-nav_order: 20
+nav_order: 21
 ---
 
 Ufo has an concept of extra environments. This is controlled by the `UFO_ENV_EXTRA` variable.  By setting `UFO_ENV_EXTRA` you can create additional identical ECS services or environments.

--- a/docs/_docs/ufo-env.md
+++ b/docs/_docs/ufo-env.md
@@ -1,6 +1,6 @@
 ---
 title: UFO_ENV
-nav_order: 19
+nav_order: 20
 ---
 
 Ufo's behavior is controlled by the `UFO_ENV` environment variable.  For example, the `UFO_ENV` variable is used to layer different ufo variable files together to make it easy to specify settings for different environments like production and development.  This is covered thoroughly in the [Variables]({% link _docs/variables.md %}) section.  `UFO_ENV` defaults to `development` when not set.

--- a/docs/_docs/ufo-task-params.md
+++ b/docs/_docs/ufo-task-params.md
@@ -1,9 +1,18 @@
 ---
-title: Params
-nav_order: 15
+title: Ufo Task Params
+nav_order: 23
 ---
 
-Additionally, the params that ufo sends to the [ruby aws-sdk](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method) methods to create resources can be customized with a `params.yml` file.  This allows you to customize the tool using the full power of the aws-sdk.
+You can run one off task with the [ufo task](https://ufoships.com/reference/ufo-task/) command.
+
+The `ufo task` commands:
+
+1. Builds the docker image
+2. Registers the ECS task definition
+3. Runs the command
+
+
+The params that ufo sends to the [ruby aws-sdk](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#run_task-instance_method) methods to for the one off task can be customized with a `params.yml` file.  This allows you use the full power of the aws-sdk.
 
 A starter project `.ufo/params.yml` file is generated as part of the `ufo init` command. Let's take a look at an example `params.yml`:
 
@@ -27,10 +36,8 @@ run_task:
 
 Ufo provides 1st class citizen access to adjust the params sent to the aws-sdk calls:
 
-The parameters from this `params.yml` file get merged with params ufo generates internally.  Here's an example of where the merging happens in the source code for the run task command [task.rb](https://github.com/tongueroo/ufo/blob/master/lib/ufo/task.rb).  Also, here's the starter [params.yml source code](https://github.com/tongueroo/ufo/blob/master/lib/template/.ufo/params.yml.tt) for reference.
-
 ERB and [shared variables]({% link _docs/variables.md %}) are available in the params file.  You can also define the subnets in your config/variables and use them in them in the params.yml file.
 
-NOTE: The params.yml file does not have access to the `task_definition_name` helper method. That is only available in the `task_definitions.rb` template_definition code blocks.
+Note, the params.yml file does not have access to the `task_definition_name` helper method. That is only available in the `task_definitions.rb` template_definition code blocks.
 
 {% include prev_next.md %}

--- a/docs/_docs/upgrading.md
+++ b/docs/_docs/upgrading.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading
-nav_order: 30
+nav_order: 32
 ---
 
 <ul>

--- a/docs/_docs/upgrading/upgrade4.5.md
+++ b/docs/_docs/upgrading/upgrade4.5.md
@@ -3,7 +3,7 @@ title: Upgrading to Version 4.5
 short_title: Version 4.5
 order: 1
 categories: upgrading
-nav_order: 31
+nav_order: 33
 ---
 
 In ufo version 4.4 and 4.5, the default cloudformation stack names used by ufo were changed.

--- a/docs/_docs/upgrading/upgrade4.md
+++ b/docs/_docs/upgrading/upgrade4.md
@@ -3,7 +3,7 @@ title: Upgrading to Version 4.0
 short_title: Version 4.0
 order: 2
 categories: upgrading
-nav_order: 32
+nav_order: 34
 ---
 
 A major change in ufo from version 3 to 4 is that the ECS service is now created by CloudFormation. If you have an existing ECS service deployed by ufo version 3, when you deploy your app again with ufo version 4, there will be a new additional ECS service created. Here is the recommended upgrade path.

--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -1,6 +1,6 @@
 ---
 title: Shared Variables
-nav_order: 16
+nav_order: 17
 ---
 
 Often, you end up using the set of common variables across your task definitions for a project.  Ufo supports a shared variables concept to support this.  You specify variables files in the `.ufo/variables` folder and they are made available to your `.ufo/task_definitions.rb` as well as your `.ufo/templates` files.

--- a/docs/_includes/subnav.html
+++ b/docs/_includes/subnav.html
@@ -15,16 +15,23 @@
         <li><a href="{% link docs.md %}">Docs</a>
             <ul>
                 <li><a href="{% link _docs/structure.md %}">Structure</a></li>
-                <li><a href="{% link _docs/settings.md %}">Settings</a></li>
-                <li><a href="{% link _docs/settings-network.md %}">Settings Network</a></li>
-                <li><a href="{% link _docs/settings-cfn.md %}">Settings Cfn</a></li>
-                <li><a href="{% link _docs/params.md %}">Params</a></li>
+                <li><a href="{% link _docs/settings.md %}">Settings</a>
+                    <ul>
+                        {% assign docs = site.docs | where: "categories","settings" | sort: "order" %}
+                        {% for doc in docs -%}
+                          <li><a href='{{doc.url}}'>{{doc.short_title}}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
                 <li><a href="{% link _docs/variables.md %}">Shared Variables</a></li>
                 <li><a href="{% link _docs/helpers.md %}">Helpers</a></li>
                 <li><a href="{% link _docs/conventions.md %}">Conventions</a></li>
                 <li><a href="{% link _docs/ufo-env.md %}">Ufo Env</a></li>
                 <li><a href="{% link _docs/ufo-env-extra.md %}">Ufo Env Extra</a></li>
                 <li><a href="{% link _docs/ufo-current.md %}">Ufo Current</a></li>
+                <li><a href="{% link _docs/ufo-task-params.md %}">Ufo Task Params</a></li>
+            </ul>
+        </li>
         <li>Extras
             <ul>
                 <li><a href="{% link _docs/extras/load-balancer.md %}">Load Balancer</a></li>
@@ -36,6 +43,7 @@
                 <li><a href="{% link _docs/extras/minimal-deploy-iam.md %}">Minimal Deploy IAM</a></li>
                 <li><a href="{% link _docs/extras/codebuild-iam-role.md %}">CodeBuild IAM Role</a></li>
             </ul>
+        </li>
         <li><a href="{% link _docs/upgrading.md %}">Upgrading</a>
             <ul>
                 {% assign docs = site.docs | where: "categories","upgrading" | sort: "order" %}

--- a/docs/_reference/ufo-apps.md
+++ b/docs/_reference/ufo-apps.md
@@ -28,6 +28,7 @@ This command lists ECS services for an ECS cluster. It includes ECS services tha
 ## Options
 
 ```
+[--clusters=one two three]   # List of clusters
 [--verbose], [--no-verbose]  
 [--mute], [--no-mute]        
 [--noop], [--no-noop]        

--- a/docs/_reference/ufo-task.md
+++ b/docs/_reference/ufo-task.md
@@ -11,6 +11,12 @@ reference: true
 
 Run a one-time task.
 
+The `ufo task` commands:
+
+1. Builds the docker image
+2. Registers the ECS task definition
+3. Runs the command
+
 ## Examples
 
 You can use the `--command` or `-c` option to override the Docker container command.
@@ -28,6 +34,10 @@ The `--task-only` option is useful. By default, the `ufo task` command will buil
     ufo task demo-web -c uptime # build at least once
     ufo task demo-web --task-only -c ls # skip docker for speed
     ufo task demo-web --task-only -c pwd # skip docker for speed
+
+## Params
+
+You can control and customize the params that get sent to the ECS run_task call with a `config/params.yml` file. More info here: https://ufoships.com/docs/ufo-task-params/
 
 
 ## Options

--- a/docs/_reference/ufo-upgrade-v43to45.md
+++ b/docs/_reference/ufo-upgrade-v43to45.md
@@ -10,3 +10,6 @@ reference: true
 ## Description
 
 Upgrade from version 4.3 and 4.4 to 4.5
+
+
+

--- a/docs/_reference/ufo-upgrade-v43to45.md
+++ b/docs/_reference/ufo-upgrade-v43to45.md
@@ -10,6 +10,3 @@ reference: true
 ## Description
 
 Upgrade from version 4.3 and 4.4 to 4.5
-
-
-

--- a/docs/articles.md
+++ b/docs/articles.md
@@ -1,6 +1,6 @@
 ---
 title: Articles
-nav_order: 42
+nav_order: 44
 ---
 
 * [How to Create Unlimited Extra Environments

--- a/lib/ufo/apps/cfn_map.rb
+++ b/lib/ufo/apps/cfn_map.rb
@@ -5,7 +5,7 @@ class Ufo::Apps
 
     def initialize(options = {})
       @options = options
-      @cluster = @options[:cluster] || default_cluster
+      @cluster = @options[:cluster] || default_cluster(options[:service])
       @map = {}
     end
 

--- a/lib/ufo/apps/cluster.rb
+++ b/lib/ufo/apps/cluster.rb
@@ -1,0 +1,24 @@
+class Ufo::Apps
+  class Cluster
+    def self.all
+      new.all
+    end
+
+    def all
+      Ufo.check_ufo_project!
+      clusters = if settings[:service_cluster]
+        settings[:service_cluster].values
+      elsif settings[:cluster]
+        settings[:cluster]
+      else
+        Ufo.env
+      end
+      [clusters].flatten.compact
+    end
+
+  private
+    def settings
+      @settings ||= Ufo.settings
+    end
+  end
+end

--- a/lib/ufo/base.rb
+++ b/lib/ufo/base.rb
@@ -7,7 +7,7 @@ module Ufo
       @service = switch_current(service)
       @options = options
 
-      @cluster = @options[:cluster] || default_cluster
+      @cluster = @options[:cluster] || default_cluster(@service)
       @stack_name = adjust_stack_name(@cluster, @service)
     end
 
@@ -22,8 +22,8 @@ module Ufo
 
     def no_service_message
       <<-EOL
-No #{@service.color(:green)} found.
-No CloudFormation stack named #{@stack_name} found.
+No #{@service.color(:green)} ecs service found.
+No CloudFormation stack named #{@stack_name.color(:green)} found.
 Are sure it exists?
       EOL
     end

--- a/lib/ufo/cli.rb
+++ b/lib/ufo/cli.rb
@@ -143,8 +143,9 @@ module Ufo
 
     desc "apps", "List apps."
     long_desc Help.text(:apps)
+    option :clusters, type: :array, desc: "List of clusters"
     def apps
-      Apps.new(options).list
+      Apps.new(options).list_all
     end
 
     desc "resources SERVICE", "The ECS service resources."

--- a/lib/ufo/help/task.md
+++ b/lib/ufo/help/task.md
@@ -1,3 +1,9 @@
+The `ufo task` commands:
+
+1. Builds the docker image
+2. Registers the ECS task definition
+3. Runs the command
+
 ## Examples
 
 You can use the `--command` or `-c` option to override the Docker container command.
@@ -15,3 +21,7 @@ The `--task-only` option is useful. By default, the `ufo task` command will buil
   ufo task demo-web -c uptime # build at least once
   ufo task demo-web --task-only -c ls # skip docker for speed
   ufo task demo-web --task-only -c pwd # skip docker for speed
+
+## Params
+
+You can control and customize the params that get sent to the ECS run_task call with a `config/params.yml` file. More info here: https://ufoships.com/docs/ufo-task-params/

--- a/lib/ufo/param.rb
+++ b/lib/ufo/param.rb
@@ -9,7 +9,7 @@ module Ufo
     end
 
     def data
-      upgrade_message!
+      return {} unless File.exist?(@params_path)
 
       result = RenderMePretty.result(@params_path, context: template_scope)
       data = YAML.load(result) || {}
@@ -19,21 +19,6 @@ module Ufo
 
     def template_scope
       @template_scope ||= Ufo::TemplateScope.new(Ufo::DSL::Helper.new, nil)
-    end
-
-    # Ufo version 3.3 to 3.4 added a concept of a .ufo/params.yml file to support
-    # fargate: https://github.com/tongueroo/ufo/pull/31
-    #
-    # Warn user and tell them to run the `ufo upgrade v3_3to3_4` command to upgrade.
-    def upgrade_message!
-      return if File.exist?(@params_path)
-
-      puts "ERROR: Your project is missing the .ufo/params.yml.".color(:red)
-      puts "This was added in ufo version 3.4"
-      puts "You can find more info about the params file here: http://ufoships.com/docs/params/"
-      puts "To upgrade run:"
-      puts "  ufo upgrade v3_3to3_4"
-      exit 1
     end
   end
 end

--- a/lib/ufo/ship.rb
+++ b/lib/ufo/ship.rb
@@ -10,13 +10,13 @@ module Ufo
     end
 
     def deploy
-      message = "Deploying #{@service}..."
+      message = "Deploying service #{@service.color(:green)} to cluster #{@cluster.color(:green)}..."
       unless @options[:mute]
         if @options[:noop]
           puts "NOOP: #{message}"
           return
         else
-          puts message.color(:green)
+          puts message
         end
       end
 

--- a/lib/ufo/stack.rb
+++ b/lib/ufo/stack.rb
@@ -33,7 +33,7 @@ module Ufo
       @options = options
       @task_definition = options[:task_definition]
       @service = options[:service]
-      @cluster = @options[:cluster] || default_cluster
+      @cluster = @options[:cluster] || default_cluster(@service)
       @stack_name = adjust_stack_name(@cluster, options[:service])
     end
 

--- a/lib/ufo/task.rb
+++ b/lib/ufo/task.rb
@@ -8,7 +8,8 @@ module Ufo
     def initialize(task_definition, options)
       @task_definition = task_definition
       @options = options
-      @cluster = @options[:cluster] || default_cluster
+      # Assume task_definition is the same name as the ecs service name
+      @cluster = @options[:cluster] || default_cluster(task_definition)
     end
 
     def run

--- a/lib/ufo/util.rb
+++ b/lib/ufo/util.rb
@@ -6,8 +6,11 @@ module Ufo
     # But it can be overriden by ufo/settings.yml cluster
     #
     # More info: http://ufoships.com/docs/settings/
-    def default_cluster
-      settings[:cluster] || Ufo.env
+    def default_cluster(service)
+      # to_s.to_sym in case service is nil
+      settings.dig(:service_cluster, service.to_s.to_sym) ||
+      settings[:cluster] ||
+      Ufo.env
     end
 
     # Keys are strings for simplicity.


### PR DESCRIPTION
Introduce service_cluster map setting. This allows us to map services to ECS clusters without having to remember to specify `--cluster` repeatedly. IE:

ECS Service | ECS Cluster
--- | ---
demo-web | web-fleet
demo-worker | worker-fleet

Before we could only map UFO_ENV to ECS clusters. With this we can also map specific services to ECS clusters.

Misc:

* also allow ufo task to work without params.yml file