### PR TITLE
Secrets in container definition 

### DIFF
--- a/lib/template/.env.secrets
+++ b/lib/template/.env.secrets
@@ -1,0 +1,2 @@
+# fine to have comment in this file
+PARAMETER_NAME

--- a/lib/template/.ufo/templates/fargate.json.erb
+++ b/lib/template/.ufo/templates/fargate.json.erb
@@ -21,6 +21,9 @@
       <% if @environment %>
       "environment": <%= @environment.to_json %>,
       <% end %>
+      <% if @secrets %>
+      "secrets": <%= @secrets.to_json %>,
+      <% end %>
       <% if @awslogs_group %>
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/lib/template/.ufo/templates/main.json.erb
+++ b/lib/template/.ufo/templates/main.json.erb
@@ -24,6 +24,9 @@
       <% if @environment %>
       "environment": <%= @environment.to_json %>,
       <% end %>
+      <% if @secrets %>
+      "secrets": <%= @secrets.to_json %>,
+      <% end %>
       <% if @awslogs_group %>
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/lib/template/.ufo/variables/base.rb.tt
+++ b/lib/template/.ufo/variables/base.rb.tt
@@ -2,8 +2,8 @@
 # More info on how variables work: http://ufoships.com/docs/variables/
 @image = helper.full_image_name # includes the git sha tongueroo/demo-ufo:ufo-[sha].
 @environment = helper.env_file(".env")
-<% if @options[:secrets] -%>
-@secrets = helper.secrets_file("/{environment}/path/to/parameter/",".env.secrets")
+<% if @options[:secrets_path] -%>
+@secrets = helper.secrets_file("<%= @options[:secrets_path] %>",".env.secrets")
 <% end -%>
 <% if @options[:launch_type] == "fargate" -%>
 # Ensure that the cpu and memory values are a supported combination by Fargate.

--- a/lib/template/.ufo/variables/base.rb.tt
+++ b/lib/template/.ufo/variables/base.rb.tt
@@ -2,6 +2,9 @@
 # More info on how variables work: http://ufoships.com/docs/variables/
 @image = helper.full_image_name # includes the git sha tongueroo/demo-ufo:ufo-[sha].
 @environment = helper.env_file(".env")
+<% if @options[:secrets] -%>
+@secrets = helper.secrets_file("/{environment}/path/to/parameter/",".env.secrets")
+<% end -%>
 <% if @options[:launch_type] == "fargate" -%>
 # Ensure that the cpu and memory values are a supported combination by Fargate.
 # More info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html"

--- a/lib/ufo/dsl/helper.rb
+++ b/lib/ufo/dsl/helper.rb
@@ -41,6 +41,20 @@ module Ufo
         end
       end
 
+      def secrets(text)
+        lines = filtered_lines(text)
+        lines.map do |line|
+          key,*value = line.strip.split("=").map do |x|
+            remove_surrounding_quotes(x.strip)
+          end
+          value = value.join('=')
+          {
+              name: key,
+              valueFrom: value,
+          }
+        end
+      end
+
       def remove_surrounding_quotes(s)
         if s =~ /^"/ && s =~ /"$/
           s.sub(/^["]/, '').gsub(/["]$/,'') # remove surrounding double quotes

--- a/lib/ufo/dsl/helper.rb
+++ b/lib/ufo/dsl/helper.rb
@@ -45,7 +45,7 @@ module Ufo
         lines = filtered_lines(text)
         lines.map do |line|
           key = remove_surrounding_quotes(line.strip)
-          path.gsub!("{environment}", ENV['UFO_ENV'])
+          path.gsub!("{environment}", Ufo.env)
           value = path + key
           {
               name: key,

--- a/lib/ufo/dsl/helper.rb
+++ b/lib/ufo/dsl/helper.rb
@@ -41,13 +41,12 @@ module Ufo
         end
       end
 
-      def secrets(text)
+      def secrets(path,text)
         lines = filtered_lines(text)
         lines.map do |line|
-          key,*value = line.strip.split("=").map do |x|
-            remove_surrounding_quotes(x.strip)
-          end
-          value = value.join('=')
+          key = remove_surrounding_quotes(line.strip)
+          path.gsub!("{environment}", ENV['UFO_ENV'])
+          value = path + key
           {
               name: key,
               valueFrom: value,
@@ -83,6 +82,16 @@ module Ufo
         end
         text = IO.read(full_path)
         env_vars(text)
+      end
+
+      def secrets_file(paramPath,filepath)
+        full_path = "#{Ufo.root}/#{filepath}"
+        unless File.exist?(full_path)
+          puts "The #{full_path} secrets file could not be found.  Are you sure it exists?"
+          exit 1
+        end
+        text = IO.read(full_path)
+        secrets(paramPath,text)
       end
 
       def current_region

--- a/lib/ufo/init.rb
+++ b/lib/ufo/init.rb
@@ -10,6 +10,7 @@ module Ufo
         [:app, desc: "App name. Preferably one word. Used in the generated ufo/task_definitions.rb.  If not specified then the app name is inferred as the folder name."],
         [:launch_type, default: "ec2", desc: "ec2 or fargate."],
         [:execution_role_arn, desc: "execution role arn used by tasks, required for fargate."],
+        [:secrets_path, desc: "Secrets path for aws ssm parameter store {environment} in the path will be substituted with the UFO_ENV"],
         [:template, desc: "Custom template to use."],
         [:template_mode, desc: "Template mode: replace or additive."],
         [:vpc_id, desc: "Vpc id. For settings/network/default.yml."],

--- a/lib/ufo/version.rb
+++ b/lib/ufo/version.rb
@@ -1,3 +1,3 @@
 module Ufo
-  VERSION = "4.6.3"
+  VERSION = "4.6.4"
 end


### PR DESCRIPTION
TODO: Update documentation when implementation is approved
* Update template files to insert secrets
* Create helper method for secrets and secrets_file
* Add `--secrets_path` to specify aws ssm parameter path (ex. --secrets_path=/{environment}/path/to/parameter/ )
* Will substitute {environment} in the path to the current UFO_ENV
* Tested task-definition generation on my work project using Fargate

Resolves #76 