### PR TITLE
Add support of credsStore

### DIFF
--- a/spec/lib/ecr_auth_spec.rb
+++ b/spec/lib/ecr_auth_spec.rb
@@ -1,36 +1,48 @@
 describe Ufo::Ecr::Auth do
   let(:repo_domain) { "123456789.dkr.ecr.us-east-1.amazonaws.com" }
+  let(:username) { "user" }
+  let(:password) { "opensesame" }
   let(:auth) { Ufo::Ecr::Auth.new(repo_domain) }
   before(:each) do
-    allow(auth).to receive(:fetch_auth_token).and_return("opensesame")
+    allow(auth).to receive(:fetch_auth_token).and_return(Base64.encode64("#{username}:#{password}"))
   end
 
   context("update") do
-    before(:each) do
-      clean_home
-    end
+    context("with ecr repo") do
+      context("when login successful") do
+        it "should create the auth token" do
+          command = "docker login -u #{username} --password-stdin #{repo_domain}"
+          command_result = double(success?: true)
+          expect(Open3).to receive(:capture3)
+            .with(command, stdin_data: password)
+            .and_return(['', '', command_result])
 
-    context("missing ~/.docker/config.json") do
-      it "should create the auth token" do
-        auth.update
-        data = JSON.load(IO.read("spec/fixtures/home/.docker/config.json"))
-        auth_token = data["auths"][repo_domain]["auth"]
-        expect(auth_token).to eq("opensesame")
+          auth.update
+        end
+      end
+
+      context("when login failed") do
+        it "should exit with code 1" do
+          command = "docker login -u #{username} --password-stdin #{repo_domain}"
+          command_result = double(success?: false)
+          expect(Open3).to receive(:capture3)
+            .with(command, stdin_data: password)
+            .and_return(['', '', command_result])
+          expect(auth).to receive(:exit).with(1)
+
+          auth.update
+        end
       end
     end
 
-    context("existing ~/.docker/config.json") do
-      it "should update the auth token" do
+    context("with not ecr repo") do
+      let(:repo_domain) { "example/test" }
+
+      it "should not update credentials" do
+        expect(Open3).not_to receive(:capture3)
+
         auth.update
-        data = JSON.load(IO.read("spec/fixtures/home/.docker/config.json"))
-        auth_token = data["auths"][repo_domain]["auth"]
-        expect(auth_token).to eq("opensesame")
       end
     end
-  end
-
-  def clean_home
-    FileUtils.rm_rf("spec/fixtures/home")
-    FileUtils.cp_r("spec/fixtures/home_existing", "spec/fixtures/home")
   end
 end


### PR DESCRIPTION
Added support for `credsStore` parameter of Docker `config.json` file. https://docs.docker.com/engine/reference/commandline/login/

- Using `docker login` instead of overwriting `config.json` file