### PR TITLE
Allow custom container name when you try to attach an existing ELB to a service

### DIFF
--- a/lib/ufo/stack/builder/resources/ecs.rb
+++ b/lib/ufo/stack/builder/resources/ecs.rb
@@ -32,7 +32,7 @@ class Ufo::Stack::Builder::Resources
             "CreateTargetGroupIsTrue",
             [
               {
-                ContainerName: "web",
+                ContainerName: @container[:name],
                 ContainerPort: @container[:port],
                 TargetGroupArn: {Ref: "TargetGroup"}
               }
@@ -43,7 +43,7 @@ class Ufo::Stack::Builder::Resources
                 [],
                 [
                   {
-                    ContainerName: "web",
+                    ContainerName: @container[:name],
                     ContainerPort: @container[:port],
                     TargetGroupArn: {Ref: "ElbTargetGroup"}
                   }


### PR DESCRIPTION
This PR allows using of custom container name (not "web") when you use `--elb true` or `--elb EXISTING_ELB_TARGET_GROUP`